### PR TITLE
Bump mpl-core, solana-sdk and carbon crates to highest possible versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-carbon-core = "0.9"
-carbon-proc-macros = "0.9"
-carbon-macros = "0.9"
-solana-sdk = "2.1"
+carbon-core = "0.11"
+carbon-proc-macros = "0.11"
+carbon-macros = "0.11"
+solana-sdk = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.3"
 mpl-core = { version = "0.11.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-carbon-core = "0.6"
-carbon-proc-macros = "0.6"
-carbon-macros = "0.6"
+carbon-core = "0.9"
+carbon-proc-macros = "0.9"
+carbon-macros = "0.9"
 solana-sdk = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.3"
-mpl-core = { version = "0.8.0" }
+mpl-core = { version = "0.11.1" }
 serde-big-array = "0.5"
 mpl-bubblegum = { git = "https://github.com/metaplex-foundation/mpl-bubblegum", branch = "main" }
 


### PR DESCRIPTION
# Description
- Bumps `mpl-core`, `solana-sdk` and `carbon` crates to highest versions without conflicts.
- This is required so we have the latest Meteora DLMM decoders from Carbon.
[Ticket](https://phaselabs.monday.com/boards/1955885194/views/43452170/pulses/2525907339)

# Testing Instructions
Ensure your Netrunner code on [this](https://github.com/phaselabscrypto/netrunner-v2-api/pull/637) branch builds and runs properly.